### PR TITLE
Document translatable exception and validation error messages in i18n interface

### DIFF
--- a/docs/application-developers/core-development-guide/i18n/i18n-interface.md
+++ b/docs/application-developers/core-development-guide/i18n/i18n-interface.md
@@ -44,6 +44,75 @@ This section translates specific [Views](../views-ui/frontend-logic.md) and thei
 
 Used for translating form validation errors or specific controller exceptions.
 
+### Error Message Translations
+
+Error messages raised through exceptions must be translatable.
+
+#### 1. Exception-based error messages
+
+When throwing an exception, the message string is used as the translation key:
+
+```php
+throw new \Exception('cannot_remove_non_proforma', EQ_ERROR_NOT_ALLOWED);
+```
+
+- The string `'cannot_remove_non_proforma'` acts as the **error identifier**.
+- This identifier must be defined in the translation file of the related class, under the `"error"` section.
+
+#### 2. Field-related error messages
+
+By default, error keys are organized by **field name**.
+
+Each field contains a set of error messages related to validation rules (for example: constraints, uniqueness).
+
+Example:
+
+```json
+"error": {
+    "login": {
+        "invalid_email": "Must be a valid email address."
+    },
+    "firstname": {
+        "too_short": "Must contain at least 2 characters.",
+        "invalid_chars": "Must not contain symbolic characters."
+    }
+}
+```
+
+- These messages are typically triggered by validation logic.
+- Structure: `error → field → error_code → translated message`
+
+#### 3. Global (non-field) error messages
+
+Errors that are **not linked to a specific field** must be defined under the `"errors"` key.
+
+These errors are always triggered via `throw new Exception(...)`, either:
+
+- in the class itself, or
+- in one of its associated controllers.
+
+Example:
+
+```json
+"error": {
+    "customer_id": {
+        "missing_mandatory": "Required field."
+    },
+    "center_id": {
+        "missing_mandatory": "Required field."
+    },
+    "status": {
+        "non_editable": "The booking status does not allow editing.",
+        "undefined_product_id": "Status cannot be changed if no product is defined."
+    },
+    "errors": {
+        "overbooking_detected": "Overbooking detected."
+    }
+}
+```
+
+- Structure for global errors: `error → errors → error_code → translated message`
+
 ### Comprehensive Example
 
 **File**: `packages/accounting/i18n/fr/VatRule.json`


### PR DESCRIPTION
### Motivation

- Provide clear guidance on how exception messages and validation errors must be defined for translation within the `i18n` files.
- Clarify the expected structure for field-level and global (non-field) error messages to ensure consistent localization across the codebase.

### Description

- Added an `Error Message Translations` subsection to `docs/application-developers/core-development-guide/i18n/i18n-interface.md` explaining translation expectations for errors.
- Documented that exception message strings are used as translation keys and provided a PHP example using `throw new \Exception('cannot_remove_non_proforma', EQ_ERROR_NOT_ALLOWED);`.
- Described the field-related error structure as `error → field → error_code → translated message` and provided a JSON example illustrating validation messages.
- Described global non-field errors under `error → errors → error_code → translated message` with an example JSON snippet and guidance on when to use it.

### Testing

- No runtime tests were required because this is a documentation-only change.
- The repository and documentation changes were validated locally and the pull request was created using the project PR tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcf972d40883259ef2a950e82495b7)