### PR TITLE
Add Workbench Route Recap to URL navigation reference

### DIFF
--- a/docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md
+++ b/docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md
@@ -1,5 +1,34 @@
 # Query Parameter Navigation Reference
 
+## Workbench Route Recap
+
+| Full URL | Target |
+|---|---|
+| `/uml` | `UmlErdComponent` |
+| `/pipelines` | `PipelineComponent` |
+| `/routes` | `RoutesComponent` |
+| `/package/:package_name` | `AppComponent` |
+| `/package/:package_name/init-data/:type` | `InitDataComponent` |
+| `/package/:package_name/model/:class_name/fields` | `PackageModelFieldsComponent` |
+| `/package/:package_name/model/:class_name/translations` | `ModelTradEditorComponent` |
+| `/package/:package_name/model/:class_name/workflow` | `PackageModelWorkflowComponent` |
+| `/package/:package_name/model/:class_name/policies` | `PackageModelPoliciesComponent` |
+| `/package/:package_name/model/:class_name/actions` | `PackageModelActionsComponent` |
+| `/package/:package_name/model/:class_name/roles` | `PackageModelRolesComponent` |
+| `/package/:package_name/model/:class_name` | `AppComponent` |
+| `/package/:package_name/menu/:menu_name/translations` | `MenuTradEditorComponent` |
+| `/package/:package_name/menu/:menu_name/edit` | `PackageMenuComponent` |
+| `/package/:package_name/menu/:menu_name` | `AppComponent` |
+| `/package/:package_name/controller/:controller_type/:controller_name/edit` | `PackageControllerComponent` |
+| `/package/:package_name/controller/:controller_type/:controller_name` | `AppComponent` |
+| `/package/:package_name/route/:route_name` | `AppComponent` |
+| `/package/:package_name/routes` | `AppComponent` |
+| `/package/:package_name/package/:package_name` | `PackageComponent` |
+| `/package/:package_name/view/:entity_view/edit` | `PackageViewComponent` |
+| `/package/:package_name/view/:entity_view` | `AppComponent` |
+
+---
+
 This document lists the available query parameters and link patterns used for deep navigation in editors. This is intended as a reference for developers to understand and utilize the navigation system effectively. For specifics about implementation and usage, refer to the `QueryParamNavigatorService` code and related editor components.
 
 ---


### PR DESCRIPTION
### Motivation

- Provide a concise, easy-to-scan recap of the Workbench routes so developers can quickly find route patterns and their target components. 

### Description

- Inserted a new `Workbench Route Recap` section at the top of `docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md` containing a table of full route patterns and their target components. 
- Kept the existing query-parameter navigation reference content unchanged and placed it below the new recap section. 

### Testing

- Inspected the updated file to verify the new section appears at the top using `nl -ba docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md | sed -n '1,120p'`, which succeeded. 
- Verified the file content was saved to the repository and the change is visible in the working tree, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1ffc6590483258077f59ffe51c2ff)