### PR TITLE
Add Workbench routing introduction to URL navigation reference

### DIFF
--- a/docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md
+++ b/docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md
@@ -1,5 +1,9 @@
 # Query Parameter Navigation Reference
 
+Workbench routing follows a hybrid pattern. Some URLs load dedicated feature screens, while others resolve to a shared multi-purpose entry screen. This is intentional: the Workbench home screen is not just a landing page, but a generic inspector driven by the current URL. It interprets the route, restores the selected package, model, view, menu, controller, or route, and then renders the corresponding information panel.
+
+As a result, several routes point to the same `AppComponent`. That component acts as a universal URL-driven inspector, whereas more specialized sub-routes load dedicated editing modules for tasks such as fields, translations, workflow, policies, actions, roles, or view editing.
+
 ## Workbench Route Recap
 
 | Full URL | Target |


### PR DESCRIPTION
### Motivation
- Clarify the Workbench routing model by explaining the hybrid pattern and why several routes intentionally resolve to the same `AppComponent` so developers understand the URL-driven inspector behavior.

### Description
- Added a short introductory paragraph at the top of `docs/application-developers/how-tos-references/workbench/workbench-url-navigation.md` that explains the distinction between dedicated feature screens and the multi-purpose URL-driven `AppComponent`, and notes that specialized editor modules are used for fields, translations, workflow, policies, actions, roles, and view editing.

### Testing
- Documentation-only change; previewed the updated `workbench-url-navigation.md` file to verify the new introduction is present and no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f20093cb788325a241fa135303e2ec)